### PR TITLE
Set useSSL property to false for MySQL connections

### DIFF
--- a/src/main/java/com/griefcraft/sql/Database.java
+++ b/src/main/java/com/griefcraft/sql/Database.java
@@ -254,6 +254,7 @@ public abstract class Database {
 			properties.put("autoReconnect", "true");
 			properties.put("user", lwc.getConfiguration().getString("database.username"));
 			properties.put("password", lwc.getConfiguration().getString("database.password"));
+			properties.put("useSSL", "false");
 		}
 
 		// Connect to the database


### PR DESCRIPTION
This should prevent the very annoying ` Establishing SSL connection without server's identity verification is not recommended. ` message.

I am going to be completely honest and say that I didn't test this change, but I'm quite sure it will work, and though it'd be better to come with a contribution instead of just creating an issue.