### PR TITLE
Fix getting a player in a range

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -906,7 +906,7 @@ public class LWC {
 			int plrZ = location.getBlockZ();
 
 			// simple check of the ranges
-			if (plrX >= minX && plrX <= maxX && plrY >= plrY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
+			if (plrX >= minX && plrX <= maxX && plrY >= minY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
 				return player;
 			}
 		}


### PR DESCRIPTION
Previously, this method would return a player fulfilling the other range requirements as long as they weren't above the max Y value. The method checked the player's Y value against itself instead of the min Y value.

This change ensures that the method checks against all of the values passed to it.