### PR TITLE
Cleanup static variables

### DIFF
--- a/src/main/java/com/griefcraft/cache/BlockCache.java
+++ b/src/main/java/com/griefcraft/cache/BlockCache.java
@@ -75,6 +75,13 @@ public class BlockCache {
     }
 
     /**
+     * Clean up the singleton instance when disabling.
+     */
+    public static void destruct() {
+        blockCache = null;
+    }
+
+    /**
      * Add a mapping to both maps. Only to be used internally.
      *
      * @param integer

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -619,6 +619,9 @@ public class LWC {
 		}
 
 		physicalDatabase = null;
+
+		// Clean ourselves up
+		instance = null;
 	}
 
 	/**

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -906,7 +906,7 @@ public class LWC {
 			int plrZ = location.getBlockZ();
 
 			// simple check of the ranges
-			if (plrX >= minX && plrX <= maxX && plrY >= plrY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
+			if (plrX >= minX && plrX <= maxX && plrY >= minY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
 				return player;
 			}
 		}

--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -28,6 +28,7 @@
 
 package com.griefcraft.lwc;
 
+import com.griefcraft.cache.BlockCache;
 import com.griefcraft.listeners.LWCBlockListener;
 import com.griefcraft.listeners.LWCEntityListener;
 import com.griefcraft.listeners.LWCPlayerListener;
@@ -192,6 +193,9 @@ public class LWCPlugin extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		LWC.ENABLED = false;
+
+		// Clean up static instances
+		BlockCache.destruct();
 
 		if (lwc != null) {
 			lwc.destruct();


### PR DESCRIPTION
This will ensure that global static variables are cleaned up when the plugin is disabled. This makes sure that the garbage collector gets them, and nothing is left hanging.

For some reason, this PR wants to PR an already accepted commit, so we'll see if this works...