### PR TITLE
Version check to get proper signs for version 1.13/1.14

### DIFF
--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -98,10 +98,6 @@ public class LimitsV2 extends JavaModule {
      * Set of materials for the various sign blocks used in the sign limit
      */
     private final Set<Material> signs = VersionUtils.getSignSet();
-    /*private final Set<Material> signs = EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
-            Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
-            Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
-            Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);*/
 
     {
         for (Material material : Material.values()) {

--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -95,7 +95,7 @@ public class LimitsV2 extends JavaModule {
     private final Map<String, Material> materialCache = new HashMap<>();
 
     /**
-     * Set of materials for the various sign blocks used in the sign limi
+     * Set of materials for the various sign blocks used in the sign limit
      */
     private final Set<Material> signs = VersionUtil.getLimitV2Set();
 

--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -36,6 +36,7 @@ import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
 import com.griefcraft.scripting.event.LWCReloadEvent;
 import com.griefcraft.util.Colors;
+import com.griefcraft.util.VersionUtils;
 import com.griefcraft.util.config.Configuration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -48,7 +49,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -97,10 +97,11 @@ public class LimitsV2 extends JavaModule {
     /**
      * Set of materials for the various sign blocks used in the sign limit
      */
-    private final Set<Material> signs = EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
+    private final Set<Material> signs = VersionUtils.getSignSet();
+    /*private final Set<Material> signs = EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
             Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
             Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
-            Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);
+            Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);*/
 
     {
         for (Material material : Material.values()) {

--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -95,7 +95,7 @@ public class LimitsV2 extends JavaModule {
     private final Map<String, Material> materialCache = new HashMap<>();
 
     /**
-     * Set of materials for the various sign blocks used in the sign limit
+     * Set of materials for the various sign blocks used in the sign limi
      */
     private final Set<Material> signs = VersionUtil.getLimitV2Set();
 

--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -36,7 +36,7 @@ import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
 import com.griefcraft.scripting.event.LWCReloadEvent;
 import com.griefcraft.util.Colors;
-import com.griefcraft.util.VersionUtils;
+import com.griefcraft.util.VersionUtil;
 import com.griefcraft.util.config.Configuration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -97,7 +97,7 @@ public class LimitsV2 extends JavaModule {
     /**
      * Set of materials for the various sign blocks used in the sign limit
      */
-    private final Set<Material> signs = VersionUtils.getSignSet();
+    private final Set<Material> signs = VersionUtil.getSignSet();
 
     {
         for (Material material : Material.values()) {

--- a/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
+++ b/src/main/java/com/griefcraft/modules/limits/LimitsV2.java
@@ -97,7 +97,7 @@ public class LimitsV2 extends JavaModule {
     /**
      * Set of materials for the various sign blocks used in the sign limit
      */
-    private final Set<Material> signs = VersionUtil.getSignSet();
+    private final Set<Material> signs = VersionUtil.getLimitV2Set();
 
     {
         for (Material material : Material.values()) {

--- a/src/main/java/com/griefcraft/sql/PhysDB.java
+++ b/src/main/java/com/griefcraft/sql/PhysDB.java
@@ -41,8 +41,8 @@ import com.griefcraft.modules.limits.LimitsModule;
 import com.griefcraft.scripting.Module;
 import com.griefcraft.util.MaterialUtil;
 import com.griefcraft.util.UUIDRegistry;
+import com.griefcraft.util.VersionUtil;
 import com.griefcraft.util.config.Configuration;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -60,8 +60,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class PhysDB extends Database {
 
@@ -2297,11 +2295,7 @@ public class PhysDB extends Database {
      * Update the database for the "Village and Pillage" update, otherwise known as MineCraft 1.14.
      */
     private void doUpdateVillageAndPillage() {
-        Matcher versionCheck = Pattern.compile("\\d[.]\\d+").matcher(Bukkit.getVersion());
-        if (!versionCheck.find()) {
-            return;
-        }
-        int minorVersion = Integer.parseInt(versionCheck.group().substring(2));
+        int minorVersion = VersionUtil.versionCheck();
         if (minorVersion >= 14) {
             Statement statement = null;
             try {

--- a/src/main/java/com/griefcraft/util/VersionUtil.java
+++ b/src/main/java/com/griefcraft/util/VersionUtil.java
@@ -6,25 +6,18 @@ import org.bukkit.Material;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-/**
- * This class is for various parts of the plugin to get the proper sign type in versions 1.13 and 1.14
- */
-public class VersionUtils {
+public class VersionUtil {
 
 
     /**
      * method that determines which signs Set to use for the LimitsV2 class
-     * - gets version from bukkit
-     * - finds the version number
-     * - checks if it is 1.14 and assigns the Set accordingly
-     * @return signs
+     * @return set of signs
      */
     public static Set<Material> getSignSet(){
-        String version = Bukkit.getServer().getClass().getPackage().getName();
-        int vNumIndex = version.indexOf("_");
-        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
-        int versionNum = Integer.parseInt(vSub);
+        int versionNum = versionCheck();
         Set<Material> signs = new HashSet<Material>();
         if (versionNum == 14){
             signs = getSigns1_14();
@@ -35,36 +28,26 @@ public class VersionUtils {
     }
 
     /**
-     * private helper method that assigns proper sign types for 1.13
-     * @return a set of legacy signs for 1.13
+     * method that determines which signs Set to use for the GravityMatcher class
+     * @return set of signs
      */
-    private static Set<Material> getSigns1_13(){
-        return EnumSet.of(Material.LEGACY_SIGN, Material.LEGACY_WALL_SIGN);
-    }
-
-    /**
-     * private helper method that assigns proper sign types for 1.14
-     * @return a set of signs for 1.14
-     */
-    private static Set<Material> getSigns1_14(){
-        return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
-                Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
-                Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
-                Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);
+    public static Set<Material> gravityMatcherSet(){
+        int versionNum = versionCheck();
+        Set<Material> gravityMatcher = new HashSet<Material>();
+        if (versionNum == 14){
+            gravityMatcher = gravityMatcherSet1_14();
+        }else{
+            gravityMatcher = gravityMatcherSet1_13();
+        }
+        return gravityMatcher;
     }
 
     /**
      * method that determines which signs Set to use for the WallMatcher class
-     * - gets version from bukkit
-     * - finds the version number
-     * - checks if it is 1.14 and assigns the Set accordingly
-     * @return signs
+     * @return set of signs
      */
     public static Set<Material> wallMatcherSet(){
-        String version = Bukkit.getServer().getClass().getPackage().getName();
-        int vNumIndex = version.indexOf("_");
-        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
-        int versionNum = Integer.parseInt(vSub);
+        int versionNum = versionCheck();
         Set<Material> wallMatcher = new HashSet<Material>();
         if (versionNum == 14){
             wallMatcher = wallMatcherSet1_14();
@@ -75,9 +58,33 @@ public class VersionUtils {
     }
 
     /**
-     * private helper method that assigns proper Material values for 1.13
-     * @return a set of legacy signs and other material values for 1.13
+     * finds the version of the server and returns it
+     * @return version int
      */
+    public static int versionCheck(){
+        Matcher versionCheck = Pattern.compile("\\d[.]\\d+").matcher(Bukkit.getVersion());
+        if (!versionCheck.find()) {
+            return 0;
+        }
+        int minorVersion = Integer.parseInt(versionCheck.group().substring(2));
+        return minorVersion;
+    }
+
+    /**
+     * private helper methods that assigns proper sign types for 1.13 and 1.14
+     * @return a set of legacy signs for 1.13 and updated sign types for 1.14
+     */
+    private static Set<Material> getSigns1_13(){
+        return EnumSet.of(Material.LEGACY_SIGN, Material.LEGACY_WALL_SIGN);
+    }
+
+    private static Set<Material> getSigns1_14(){
+        return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
+                Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
+                Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
+                Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);
+    }
+
     private static Set<Material> wallMatcherSet1_13(){
         return EnumSet.of(Material.LEGACY_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
                 Material.MAGENTA_WALL_BANNER, Material.LIGHT_BLUE_WALL_BANNER, Material.YELLOW_WALL_BANNER,
@@ -87,10 +94,6 @@ public class VersionUtils {
                 Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
     }
 
-    /**
-     * private helper method that assigns proper Material values for 1.14
-     * @return a set of signs and other material values for 1.14
-     */
     private static Set<Material> wallMatcherSet1_14(){
         return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
                 Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
@@ -102,31 +105,6 @@ public class VersionUtils {
                 Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
     }
 
-    /**
-     * method that determines which signs Set to use for the GravityMatcher class
-     * - gets version from bukkit
-     * - finds the version number
-     * - checks if it is 1.14 and assigns the Set accordingly
-     * @return signs
-     */
-    public static Set<Material> gravityMatcherSet(){
-        String version = Bukkit.getServer().getClass().getPackage().getName();
-        int vNumIndex = version.indexOf("_");
-        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
-        int versionNum = Integer.parseInt(vSub);
-        Set<Material> gravityMatcher = new HashSet<Material>();
-        if (versionNum == 14){
-            gravityMatcher = gravityMatcherSet1_14();
-        }else{
-            gravityMatcher = gravityMatcherSet1_13();
-        }
-        return gravityMatcher;
-    }
-
-    /**
-     * private helper method that assigns proper Material values for 1.13
-     * @return a set of legacy signs and other material values for 1.13
-     */
     private static Set<Material> gravityMatcherSet1_13(){
         return EnumSet.of(Material.LEGACY_SIGN, Material.RAIL,
                 Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,
@@ -141,10 +119,6 @@ public class VersionUtils {
                 Material.GREEN_BANNER, Material.RED_BANNER, Material.BLACK_BANNER, Material.ARMOR_STAND);
     }
 
-    /**
-     * private helper method that assigns proper Material values for 1.14
-     * @return a set of signs and other material values for 1.14
-     */
     private static Set<Material> gravityMatcherSet1_14(){
         return EnumSet.of(Material.OAK_SIGN, Material.BIRCH_SIGN,
                 Material.SPRUCE_SIGN, Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.RAIL,

--- a/src/main/java/com/griefcraft/util/VersionUtil.java
+++ b/src/main/java/com/griefcraft/util/VersionUtil.java
@@ -16,13 +16,13 @@ public class VersionUtil {
      * method that determines which signs Set to use for the LimitsV2 class
      * @return set of signs
      */
-    public static Set<Material> getSignSet(){
+    public static Set<Material> getLimitV2Set(){
         int versionNum = versionCheck();
         Set<Material> signs = new HashSet<Material>();
         if (versionNum == 14){
-            signs = getSigns1_14();
+            signs = getLimitV2Set1_14();
         }else{
-            signs = getSigns1_13();
+            signs = getLimitV2Set1_13();
         }
         return signs;
     }
@@ -31,13 +31,13 @@ public class VersionUtil {
      * method that determines which signs Set to use for the GravityMatcher class
      * @return set of signs
      */
-    public static Set<Material> gravityMatcherSet(){
+    public static Set<Material> getGravityMatcherSet(){
         int versionNum = versionCheck();
         Set<Material> gravityMatcher = new HashSet<Material>();
         if (versionNum == 14){
-            gravityMatcher = gravityMatcherSet1_14();
+            gravityMatcher = getGravityMatcherSet1_14();
         }else{
-            gravityMatcher = gravityMatcherSet1_13();
+            gravityMatcher = getGravityMatcherSet1_13();
         }
         return gravityMatcher;
     }
@@ -46,13 +46,13 @@ public class VersionUtil {
      * method that determines which signs Set to use for the WallMatcher class
      * @return set of signs
      */
-    public static Set<Material> wallMatcherSet(){
+    public static Set<Material> getWallMatcherSet(){
         int versionNum = versionCheck();
         Set<Material> wallMatcher = new HashSet<Material>();
         if (versionNum == 14){
-            wallMatcher = wallMatcherSet1_14();
+            wallMatcher = getWallMatcherSet1_14();
         }else{
-            wallMatcher = wallMatcherSet1_13();
+            wallMatcher = getWallMatcherSet1_13();
         }
         return wallMatcher;
     }
@@ -74,18 +74,18 @@ public class VersionUtil {
      * private helper methods that assigns proper sign types for 1.13 and 1.14
      * @return a set of legacy signs for 1.13 and updated sign types for 1.14
      */
-    private static Set<Material> getSigns1_13(){
+    private static Set<Material> getLimitV2Set1_13(){
         return EnumSet.of(Material.LEGACY_SIGN, Material.LEGACY_WALL_SIGN);
     }
 
-    private static Set<Material> getSigns1_14(){
+    private static Set<Material> getLimitV2Set1_14(){
         return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
                 Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
                 Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
                 Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);
     }
 
-    private static Set<Material> wallMatcherSet1_13(){
+    private static Set<Material> getWallMatcherSet1_13(){
         return EnumSet.of(Material.LEGACY_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
                 Material.MAGENTA_WALL_BANNER, Material.LIGHT_BLUE_WALL_BANNER, Material.YELLOW_WALL_BANNER,
                 Material.LIME_WALL_BANNER, Material.PINK_WALL_BANNER, Material.GRAY_WALL_BANNER,
@@ -94,7 +94,7 @@ public class VersionUtil {
                 Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
     }
 
-    private static Set<Material> wallMatcherSet1_14(){
+    private static Set<Material> getWallMatcherSet1_14(){
         return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
                 Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
                 Material.DARK_OAK_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
@@ -105,7 +105,7 @@ public class VersionUtil {
                 Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
     }
 
-    private static Set<Material> gravityMatcherSet1_13(){
+    private static Set<Material> getGravityMatcherSet1_13(){
         return EnumSet.of(Material.LEGACY_SIGN, Material.RAIL,
                 Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,
                 Material.BIRCH_BUTTON, Material.SPRUCE_BUTTON, Material.JUNGLE_BUTTON, Material.ACACIA_BUTTON,
@@ -119,7 +119,7 @@ public class VersionUtil {
                 Material.GREEN_BANNER, Material.RED_BANNER, Material.BLACK_BANNER, Material.ARMOR_STAND);
     }
 
-    private static Set<Material> gravityMatcherSet1_14(){
+    private static Set<Material> getGravityMatcherSet1_14(){
         return EnumSet.of(Material.OAK_SIGN, Material.BIRCH_SIGN,
                 Material.SPRUCE_SIGN, Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.RAIL,
                 Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,

--- a/src/main/java/com/griefcraft/util/VersionUtils.java
+++ b/src/main/java/com/griefcraft/util/VersionUtils.java
@@ -1,0 +1,163 @@
+package com.griefcraft.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class is for various parts of the plugin to get the proper sign type in versions 1.13 and 1.14
+ */
+public class VersionUtils {
+
+
+    /**
+     * method that determines which signs Set to use for the LimitsV2 class
+     * - gets version from bukkit
+     * - finds the version number
+     * - checks if it is 1.14 and assigns the Set accordingly
+     * @return signs
+     */
+    public static Set<Material> getSignSet(){
+        String version = Bukkit.getServer().getClass().getPackage().getName();
+        int vNumIndex = version.indexOf("_");
+        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
+        int versionNum = Integer.parseInt(vSub);
+        Set<Material> signs = new HashSet<Material>();
+        if (versionNum == 14){
+            signs = getSigns1_14();
+        }else{
+            signs = getSigns1_13();
+        }
+        return signs;
+    }
+
+    /**
+     * private helper method that assigns proper sign types for 1.13
+     * @return a set of legacy signs for 1.13
+     */
+    private static Set<Material> getSigns1_13(){
+        return EnumSet.of(Material.LEGACY_SIGN, Material.LEGACY_WALL_SIGN);
+    }
+
+    /**
+     * private helper method that assigns proper sign types for 1.14
+     * @return a set of signs for 1.14
+     */
+    private static Set<Material> getSigns1_14(){
+        return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
+                Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
+                Material.DARK_OAK_WALL_SIGN, Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN,
+                Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN);
+    }
+
+    /**
+     * method that determines which signs Set to use for the WallMatcher class
+     * - gets version from bukkit
+     * - finds the version number
+     * - checks if it is 1.14 and assigns the Set accordingly
+     * @return signs
+     */
+    public static Set<Material> wallMatcherSet(){
+        String version = Bukkit.getServer().getClass().getPackage().getName();
+        int vNumIndex = version.indexOf("_");
+        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
+        int versionNum = Integer.parseInt(vSub);
+        Set<Material> wallMatcher = new HashSet<Material>();
+        if (versionNum == 14){
+            wallMatcher = wallMatcherSet1_14();
+        }else{
+            wallMatcher = wallMatcherSet1_13();
+        }
+        return wallMatcher;
+    }
+
+    /**
+     * private helper method that assigns proper Material values for 1.13
+     * @return a set of legacy signs and other material values for 1.13
+     */
+    private static Set<Material> wallMatcherSet1_13(){
+        return EnumSet.of(Material.LEGACY_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
+                Material.MAGENTA_WALL_BANNER, Material.LIGHT_BLUE_WALL_BANNER, Material.YELLOW_WALL_BANNER,
+                Material.LIME_WALL_BANNER, Material.PINK_WALL_BANNER, Material.GRAY_WALL_BANNER,
+                Material.LIGHT_GRAY_WALL_BANNER, Material.CYAN_WALL_BANNER, Material.PURPLE_WALL_BANNER,
+                Material.BLUE_WALL_BANNER, Material.BROWN_WALL_BANNER, Material.GREEN_WALL_BANNER,
+                Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
+    }
+
+    /**
+     * private helper method that assigns proper Material values for 1.14
+     * @return a set of signs and other material values for 1.14
+     */
+    private static Set<Material> wallMatcherSet1_14(){
+        return EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
+                Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
+                Material.DARK_OAK_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
+                Material.MAGENTA_WALL_BANNER, Material.LIGHT_BLUE_WALL_BANNER, Material.YELLOW_WALL_BANNER,
+                Material.LIME_WALL_BANNER, Material.PINK_WALL_BANNER, Material.GRAY_WALL_BANNER,
+                Material.LIGHT_GRAY_WALL_BANNER, Material.CYAN_WALL_BANNER, Material.PURPLE_WALL_BANNER,
+                Material.BLUE_WALL_BANNER, Material.BROWN_WALL_BANNER, Material.GREEN_WALL_BANNER,
+                Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
+    }
+
+    /**
+     * method that determines which signs Set to use for the GravityMatcher class
+     * - gets version from bukkit
+     * - finds the version number
+     * - checks if it is 1.14 and assigns the Set accordingly
+     * @return signs
+     */
+    public static Set<Material> gravityMatcherSet(){
+        String version = Bukkit.getServer().getClass().getPackage().getName();
+        int vNumIndex = version.indexOf("_");
+        String vSub = version.substring(vNumIndex + 1, vNumIndex + 3);
+        int versionNum = Integer.parseInt(vSub);
+        Set<Material> gravityMatcher = new HashSet<Material>();
+        if (versionNum == 14){
+            gravityMatcher = gravityMatcherSet1_14();
+        }else{
+            gravityMatcher = gravityMatcherSet1_13();
+        }
+        return gravityMatcher;
+    }
+
+    /**
+     * private helper method that assigns proper Material values for 1.13
+     * @return a set of legacy signs and other material values for 1.13
+     */
+    private static Set<Material> gravityMatcherSet1_13(){
+        return EnumSet.of(Material.LEGACY_SIGN, Material.RAIL,
+                Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,
+                Material.BIRCH_BUTTON, Material.SPRUCE_BUTTON, Material.JUNGLE_BUTTON, Material.ACACIA_BUTTON,
+                Material.DARK_OAK_BUTTON, Material.STONE_BUTTON, Material.OAK_PRESSURE_PLATE,
+                Material.SPRUCE_PRESSURE_PLATE, Material.BIRCH_PRESSURE_PLATE, Material.JUNGLE_PRESSURE_PLATE,
+                Material.ACACIA_PRESSURE_PLATE, Material.DARK_OAK_PRESSURE_PLATE, Material.STONE_PRESSURE_PLATE,
+                Material.LIGHT_WEIGHTED_PRESSURE_PLATE, Material.HEAVY_WEIGHTED_PRESSURE_PLATE, Material.WHITE_BANNER,
+                Material.ORANGE_BANNER, Material.MAGENTA_BANNER, Material.LIGHT_BLUE_BANNER, Material.YELLOW_BANNER,
+                Material.LIME_BANNER, Material.PINK_BANNER, Material.GRAY_BANNER, Material.LIGHT_GRAY_BANNER,
+                Material.CYAN_BANNER, Material.PURPLE_BANNER, Material.BLUE_BANNER, Material.BROWN_BANNER,
+                Material.GREEN_BANNER, Material.RED_BANNER, Material.BLACK_BANNER, Material.ARMOR_STAND);
+    }
+
+    /**
+     * private helper method that assigns proper Material values for 1.14
+     * @return a set of signs and other material values for 1.14
+     */
+    private static Set<Material> gravityMatcherSet1_14(){
+        return EnumSet.of(Material.OAK_SIGN, Material.BIRCH_SIGN,
+                Material.SPRUCE_SIGN, Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.RAIL,
+                Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,
+                Material.BIRCH_BUTTON, Material.SPRUCE_BUTTON, Material.JUNGLE_BUTTON, Material.ACACIA_BUTTON,
+                Material.DARK_OAK_BUTTON, Material.STONE_BUTTON, Material.OAK_PRESSURE_PLATE,
+                Material.SPRUCE_PRESSURE_PLATE, Material.BIRCH_PRESSURE_PLATE, Material.JUNGLE_PRESSURE_PLATE,
+                Material.ACACIA_PRESSURE_PLATE, Material.DARK_OAK_PRESSURE_PLATE, Material.STONE_PRESSURE_PLATE,
+                Material.LIGHT_WEIGHTED_PRESSURE_PLATE, Material.HEAVY_WEIGHTED_PRESSURE_PLATE, Material.WHITE_BANNER,
+                Material.ORANGE_BANNER, Material.MAGENTA_BANNER, Material.LIGHT_BLUE_BANNER, Material.YELLOW_BANNER,
+                Material.LIME_BANNER, Material.PINK_BANNER, Material.GRAY_BANNER, Material.LIGHT_GRAY_BANNER,
+                Material.CYAN_BANNER, Material.PURPLE_BANNER, Material.BLUE_BANNER, Material.BROWN_BANNER,
+                Material.GREEN_BANNER, Material.RED_BANNER, Material.BLACK_BANNER, Material.ARMOR_STAND);
+    }
+
+}

--- a/src/main/java/com/griefcraft/util/matchers/GravityMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/GravityMatcher.java
@@ -28,12 +28,12 @@
 
 package com.griefcraft.util.matchers;
 
+import com.griefcraft.util.VersionUtils;
 import com.griefcraft.util.ProtectionFinder;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 
-import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -41,18 +41,7 @@ import java.util.Set;
  */
 public class GravityMatcher implements ProtectionFinder.Matcher {
 
-    public static final Set<Material> PROTECTABLES_POSTS = EnumSet.of(Material.OAK_SIGN, Material.BIRCH_SIGN,
-            Material.SPRUCE_SIGN, Material.JUNGLE_SIGN, Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.RAIL,
-            Material.ACTIVATOR_RAIL, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.LEVER, Material.OAK_BUTTON,
-            Material.BIRCH_BUTTON, Material.SPRUCE_BUTTON, Material.JUNGLE_BUTTON, Material.ACACIA_BUTTON,
-            Material.DARK_OAK_BUTTON, Material.STONE_BUTTON, Material.OAK_PRESSURE_PLATE,
-            Material.SPRUCE_PRESSURE_PLATE, Material.BIRCH_PRESSURE_PLATE, Material.JUNGLE_PRESSURE_PLATE,
-            Material.ACACIA_PRESSURE_PLATE, Material.DARK_OAK_PRESSURE_PLATE, Material.STONE_PRESSURE_PLATE,
-            Material.LIGHT_WEIGHTED_PRESSURE_PLATE, Material.HEAVY_WEIGHTED_PRESSURE_PLATE, Material.WHITE_BANNER,
-            Material.ORANGE_BANNER, Material.MAGENTA_BANNER, Material.LIGHT_BLUE_BANNER, Material.YELLOW_BANNER,
-            Material.LIME_BANNER, Material.PINK_BANNER, Material.GRAY_BANNER, Material.LIGHT_GRAY_BANNER,
-            Material.CYAN_BANNER, Material.PURPLE_BANNER, Material.BLUE_BANNER, Material.BROWN_BANNER,
-            Material.GREEN_BANNER, Material.RED_BANNER, Material.BLACK_BANNER, Material.ARMOR_STAND);
+    public static final Set<Material> PROTECTABLES_POSTS = VersionUtils.gravityMatcherSet();
 
     public boolean matches(ProtectionFinder finder) {
         Block block = finder.getBaseBlock().getBlock();

--- a/src/main/java/com/griefcraft/util/matchers/GravityMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/GravityMatcher.java
@@ -28,7 +28,7 @@
 
 package com.griefcraft.util.matchers;
 
-import com.griefcraft.util.VersionUtils;
+import com.griefcraft.util.VersionUtil;
 import com.griefcraft.util.ProtectionFinder;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -41,7 +41,7 @@ import java.util.Set;
  */
 public class GravityMatcher implements ProtectionFinder.Matcher {
 
-    public static final Set<Material> PROTECTABLES_POSTS = VersionUtils.gravityMatcherSet();
+    public static final Set<Material> PROTECTABLES_POSTS = VersionUtil.gravityMatcherSet();
 
     public boolean matches(ProtectionFinder finder) {
         Block block = finder.getBaseBlock().getBlock();

--- a/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
@@ -28,7 +28,7 @@
 
 package com.griefcraft.util.matchers;
 
-import com.griefcraft.util.VersionUtils;
+import com.griefcraft.util.VersionUtil;
 import com.griefcraft.util.ProtectionFinder;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -48,7 +48,7 @@ public class WallMatcher implements ProtectionFinder.Matcher {
      * Blocks that can be attached to the wall and be protected. This assumes that
      * the block is DESTROYED if the wall they are attached to is broken.
      */
-    public static final Set<Material> PROTECTABLES_WALL = VersionUtils.wallMatcherSet();
+    public static final Set<Material> PROTECTABLES_WALL = VersionUtil.wallMatcherSet();
 
     /**
      * Those evil levers and buttons have all different bits for directions. Gah!

--- a/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
+++ b/src/main/java/com/griefcraft/util/matchers/WallMatcher.java
@@ -28,6 +28,7 @@
 
 package com.griefcraft.util.matchers;
 
+import com.griefcraft.util.VersionUtils;
 import com.griefcraft.util.ProtectionFinder;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -47,14 +48,7 @@ public class WallMatcher implements ProtectionFinder.Matcher {
      * Blocks that can be attached to the wall and be protected. This assumes that
      * the block is DESTROYED if the wall they are attached to is broken.
      */
-    public static final Set<Material> PROTECTABLES_WALL = EnumSet.of(Material.OAK_WALL_SIGN, Material.BIRCH_WALL_SIGN,
-            Material.SPRUCE_WALL_SIGN, Material.JUNGLE_WALL_SIGN, Material.ACACIA_WALL_SIGN,
-            Material.DARK_OAK_WALL_SIGN, Material.WHITE_WALL_BANNER, Material.ORANGE_WALL_BANNER,
-            Material.MAGENTA_WALL_BANNER, Material.LIGHT_BLUE_WALL_BANNER, Material.YELLOW_WALL_BANNER,
-            Material.LIME_WALL_BANNER, Material.PINK_WALL_BANNER, Material.GRAY_WALL_BANNER,
-            Material.LIGHT_GRAY_WALL_BANNER, Material.CYAN_WALL_BANNER, Material.PURPLE_WALL_BANNER,
-            Material.BLUE_WALL_BANNER, Material.BROWN_WALL_BANNER, Material.GREEN_WALL_BANNER,
-            Material.RED_WALL_BANNER, Material.BLACK_WALL_BANNER);
+    public static final Set<Material> PROTECTABLES_WALL = VersionUtils.wallMatcherSet();
 
     /**
      * Those evil levers and buttons have all different bits for directions. Gah!


### PR DESCRIPTION
- Created a class to check the game version (1.13 or 1.14) and return the correct set of materials for the signs used in that version

- Updated assignment of sets in LimitsV2, GravityMatcher, and WallMatcher to use the methods in the new class


I'm sure there will be several things that will need to be changed, but this is a start anyway.
