### PR TITLE
Improved Faction claims support

### DIFF
--- a/src/main/java/com/griefcraft/modules/pluginsupport/Factions.java
+++ b/src/main/java/com/griefcraft/modules/pluginsupport/Factions.java
@@ -3,11 +3,14 @@ package com.griefcraft.modules.pluginsupport;
 import com.griefcraft.lwc.LWC;
 import com.griefcraft.scripting.JavaModule;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
+import com.massivecraft.factions.Conf;
 import com.massivecraft.factions.Board;
 import com.massivecraft.factions.FLocation;
 import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.FPlayers;
 import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.zcore.fperms.Access;
+import com.massivecraft.factions.zcore.fperms.PermissableAction;
 import org.bukkit.plugin.Plugin;
 
 public class Factions extends JavaModule {
@@ -27,13 +30,29 @@ public class Factions extends JavaModule {
         if (factions == null || !factionCheck) {
             return;
         }
+
+        boolean canProtect = false;
         FLocation fLocation = new FLocation(event.getBlock().getLocation());
         FPlayer fPlayer = FPlayers.getInstance().getByPlayer(event.getPlayer());
         Faction faction = Board.getInstance().getFactionAt(fLocation);
-        if (!faction.getFPlayers().contains(fPlayer)) {
+        Faction myFaction = fPlayer.getFaction();
+        boolean fBypass = Conf.playersWhoBypassAllProtection.contains(fPlayer.getName()) || fPlayer.isAdminBypassing();
+        boolean fWilderness = faction.isWilderness() && !Conf.wildernessDenyBuild;
+        boolean fWarzone = faction.isWarZone() && !Conf.warZoneDenyBuild;
+        boolean fSafezone = faction.isSafeZone() && !Conf.safeZoneDenyBuild;
+
+        if (fBypass || fWilderness || fWarzone || fSafezone) {
+            canProtect = true;
+        } else if (!myFaction.getRelationTo(faction).confDenyBuild(faction.hasPlayersOnline())) {
+            canProtect = true;
+        } else {
+            Access fAccess = faction.getAccess(fPlayer, PermissableAction.BUILD);
+            if (fAccess != null) { canProtect = (fAccess == Access.ALLOW); }
+        }
+
+        if (!canProtect) {
             event.getLWC().sendLocale(event.getPlayer(), "lwc.factions.blocked");
             event.setCancelled(true);
         }
     }
-
 }


### PR DESCRIPTION
* Support protecting in the Wilderness, SafeZone and WarZone
* Support bypass features from Factions
* Support protecting inside of faction claims if player has build perms (example: ally)

Explanation for the use of `Relation.confDenyBuild`: I followed what Factions [itself](https://github.com/drtshock/Factions/blob/1.6.x/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java#L244) does.